### PR TITLE
Autocomplete validation

### DIFF
--- a/client/src/components/comparison-column-autocomplete/index.tsx
+++ b/client/src/components/comparison-column-autocomplete/index.tsx
@@ -5,7 +5,7 @@ import { CheckBoxOutlineBlank, CheckBox } from '@mui/icons-material';
 interface Props {
   selectedDocument: any;
   comparisonColumns: Array<string>;
-  comparisonColumnsError: string;
+  comparisonColumnsError: Array<string>;
   handleComparisonColumnsBlur: any;
   handleComparisonColumnFieldChange: any;
   index: number;
@@ -33,6 +33,9 @@ const ComparisonColumnAutocomplete = ({
         disableCloseOnSelect={true}
         options={autocompleteOptions}
         onChange={handleComparisonColumnFieldChange}
+        // onInputChange={(x) => {
+        //   console.log('on input change-------------------', x)
+        // }}
         value={comparisonColumns}
         sx={{ width: '100%', margin: '2.5rem 0 1.5rem 0' }}
         renderOption={(props, option, { selected }) => (
@@ -50,14 +53,14 @@ const ComparisonColumnAutocomplete = ({
           {...params}
           variant="standard"
           required={true}
-          error={!!comparisonColumnsError}
-          onBlur={handleComparisonColumnsBlur}
+          error={!!comparisonColumnsError.length}
+          // onBlur={handleComparisonColumnsBlur}
           helperText={`Columns from file ${index === 0 ? 'A' : 'B'} that will be compared with columns
           from file ${index === 0 ? 'B' : 'A'} to determine match. Limit: 3 columns. Hint: the more unique a column's value is
           to a company, the better (DUNS number, company website, etc.).`}
         />)}
       />
-      {comparisonColumnsError && <Typography variant="caption" sx={{ color: '#d32f2f' }}>{comparisonColumnsError}</Typography>}
+      {comparisonColumnsError.length && <Typography variant="caption" sx={{ color: '#d32f2f' }}>{comparisonColumnsError.join('\n')}</Typography>}
     </>
   );
 }

--- a/client/src/components/comparison-column-autocomplete/index.tsx
+++ b/client/src/components/comparison-column-autocomplete/index.tsx
@@ -33,9 +33,6 @@ const ComparisonColumnAutocomplete = ({
         disableCloseOnSelect={true}
         options={autocompleteOptions}
         onChange={handleComparisonColumnFieldChange}
-        // onInputChange={(x) => {
-        //   console.log('on input change-------------------', x)
-        // }}
         value={comparisonColumns}
         sx={{ width: '100%', margin: '2.5rem 0 1.5rem 0' }}
         renderOption={(props, option, { selected }) => (
@@ -54,7 +51,7 @@ const ComparisonColumnAutocomplete = ({
           variant="standard"
           required={true}
           error={!!comparisonColumnsError.length}
-          // onBlur={handleComparisonColumnsBlur}
+          onBlur={handleComparisonColumnsBlur}
           helperText={`Columns from file ${index === 0 ? 'A' : 'B'} that will be compared with columns
           from file ${index === 0 ? 'B' : 'A'} to determine match. Limit: 3 columns. Hint: the more unique a column's value is
           to a company, the better (DUNS number, company website, etc.).`}

--- a/client/src/components/comparison-column-autocomplete/index.tsx
+++ b/client/src/components/comparison-column-autocomplete/index.tsx
@@ -57,7 +57,7 @@ const ComparisonColumnAutocomplete = ({
           to a company, the better (DUNS number, company website, etc.).`}
         />)}
       />
-      {comparisonColumnsError.length && <Typography variant="caption" sx={{ color: '#d32f2f' }}>{comparisonColumnsError.join('\n')}</Typography>}
+      {!!comparisonColumnsError.length && <Typography variant="caption" sx={{ color: '#d32f2f' }}>{comparisonColumnsError.join('\n')}</Typography>}
     </>
   );
 }

--- a/client/src/components/upload-document-column/index.tsx
+++ b/client/src/components/upload-document-column/index.tsx
@@ -9,7 +9,7 @@ import ComparisonColumnAutocompleteContainer from '../../containers/comparison-c
 interface UploadDocumentColumnProps {
   selectedDocument: any;
   comparisonColumns: Array<string>;
-  comparisonColumnsError: string;
+  comparisonColumnsError: Array<string>;
   fileSource: string;
   index: number;
   user: UserState;

--- a/client/src/components/upload-document-form/index.tsx
+++ b/client/src/components/upload-document-form/index.tsx
@@ -116,7 +116,7 @@ const UploadDocumentForm = ({
 
   const isSubmitBtnEnabled = selectedDocument1 && selectedDocument2 &&
     comparisonColumns1.length && comparisonColumns2.length &&
-    !comparisonColumns1Error && !comparisonColumns2Error;
+    !comparisonColumns1Error.length && !comparisonColumns2Error.length;
 
   return (
     <>

--- a/client/src/containers/comparison-column-autocomplete/index.tsx
+++ b/client/src/containers/comparison-column-autocomplete/index.tsx
@@ -7,7 +7,7 @@ interface Props {
   selectedDocument: any;
   comparisonColumns: Array<string>;
   changeComparisonColumn: any;
-  comparisonColumnsError: string;
+  comparisonColumnsError: Array<string>;
   setComparisonColumnsError: any;
   index: number;
 }

--- a/client/src/containers/upload-document-column/index.tsx
+++ b/client/src/containers/upload-document-column/index.tsx
@@ -7,7 +7,7 @@ interface Props {
   user: UserState;
   selectedDocument: any;
   comparisonColumns: Array<string>;
-  comparisonColumnsError: string;
+  comparisonColumnsError: Array<string>;
   fileSource: string;
   index: number;
 }

--- a/client/src/state/actions/document/index.ts
+++ b/client/src/state/actions/document/index.ts
@@ -46,15 +46,9 @@ export const setFileSource = (index: number, value: string) => ({
 });
 
 export const setComparisonColumnsError = (value: Array<string>, index: number) => {
-  let payload = '';
-  if (!value || !value.length) {
-    payload = 'Required';
-  } else if (value.length > 3) {
-    payload = 'Can only compare 3 columns in spreadsheet';
-  }
   return {
     type: SET_COMPARISON_COLUMNS_ERROR,
-    payload,
+    payload: value,
     index
   }
 }

--- a/client/src/state/reducers/document/index.ts
+++ b/client/src/state/reducers/document/index.ts
@@ -25,8 +25,8 @@ export interface DocumentState {
   resultColumns2: Array<string>;
   fileSource1: string;
   fileSource2: string;
-  comparisonColumns1Error: string;
-  comparisonColumns2Error: string;
+  comparisonColumns1Error: Array<string>;
+  comparisonColumns2Error: Array<string>;
 }
 
 const initialState: DocumentState = {
@@ -49,36 +49,90 @@ const initialState: DocumentState = {
   resultColumns2: [],
   fileSource1: 'upload',
   fileSource2: 'upload',
-  comparisonColumns1Error: '',
-  comparisonColumns2Error: '',
+  comparisonColumns1Error: [],
+  comparisonColumns2Error: [],
 };
+
+const MISMATCHED_COLUMNS_ERR = 'The number of selected columns for each file needs to match.';
+const TOO_MANY_COLUMNS_ERR = 'Limit of 3 columns exceeded.';
+const REQUIRED_ERR = 'At least 1 column is required';
 
 export const documentReducer = (state = initialState, action: any) => {
   switch (action.type) {
     case CHANGE_COMPARISON_COLUMN:
+      let errorMsg1 = [...state.comparisonColumns1Error];
+      let errorMsg2 = [...state.comparisonColumns2Error];
+      const { payload, index } = action;
+      if (!!state.comparisonColumns1.length && !!state.comparisonColumns2.length) {
+        if (
+          (index === 0 && payload.length !== state.comparisonColumns2.length) ||
+          (index === 1 && payload.length !== state.comparisonColumns1.length)
+        ) {
+          console.log('cols dont match')
+          errorMsg1.push(MISMATCHED_COLUMNS_ERR);
+          errorMsg2.push(MISMATCHED_COLUMNS_ERR);
+        } else if (
+          (index === 0 && payload.length === state.comparisonColumns2.length) ||
+          (index === 1 && payload.length === state.comparisonColumns1.length)
+        ) {
+          const errIndex1 = errorMsg1.indexOf(MISMATCHED_COLUMNS_ERR);
+          const errIndex2 = errorMsg1.indexOf(MISMATCHED_COLUMNS_ERR);
+          if (errIndex1 > -1) errorMsg1.splice(errIndex1, 1);
+          if (errIndex2 > -1) errorMsg2.splice(errIndex2, 1);
+        }
+      }
+      if (index === 0) {
+        if (payload.length > 3) {
+          errorMsg1.push(TOO_MANY_COLUMNS_ERR);
+          console.log('-------------payload longer than 3', errorMsg1);
+        } else {
+          console.log('-------------payload shorter than 3');
+          const errIndex = errorMsg1.indexOf(TOO_MANY_COLUMNS_ERR);
+          if (errIndex > -1) errorMsg1.splice(errIndex, 1)
+        }
+        if (payload.length === 0) {
+          errorMsg1.push(REQUIRED_ERR);
+        } else {
+          console.log('splicing req errr', errorMsg1, errorMsg1.indexOf(REQUIRED_ERR))
+          const errIndex = errorMsg1.indexOf(REQUIRED_ERR);
+          if (errIndex > -1) errorMsg1.splice(errIndex, 1);
+        }
+        console.log('errmessage1 after', errorMsg1)
+      } else if (index === 1) {
+        if (payload.length > 3) {
+          console.log('-------------payload longer than 3');
+          errorMsg2.push(TOO_MANY_COLUMNS_ERR)
+        } else {
+          console.log('-------------payload shorter than 3');
+          const errIndex = errorMsg2.indexOf(TOO_MANY_COLUMNS_ERR);
+          if (errIndex > -1) errorMsg2.splice(errIndex, 1);
+        }
+        if (payload.length === 0) {
+          errorMsg2.push(REQUIRED_ERR);
+        } else {
+          const errIndex = errorMsg2.indexOf(REQUIRED_ERR);
+          if (errIndex > -1) errorMsg2.splice(errIndex, 1);
+        }
+      }
+      console.log('error messages', errorMsg1, errorMsg2);
       if (action.index === 0) {
         return {
           ...state,
           comparisonColumns1: action.payload,
           resultColumns1: action.payload,
+          comparisonColumns1Error: errorMsg1,
+          comparisonColumns2Error: errorMsg2
         };
       } else {
         return {
           ...state,
           comparisonColumns2: action.payload,
           resultColumns2: action.payload,
+          comparisonColumns1Error: errorMsg1,
+          comparisonColumns2Error: errorMsg2
         };
       }
     case SET_COMPARISON_COLUMNS_ERROR:
-      // let errorMsg = '';
-      // if (
-      //   !!state.comparisonColumns1.length &&
-      //   !!state.comparisonColumns2.length &&
-      //   state.comparisonColumns1.length !== state.comparisonColumns2.length
-      // ) {
-      //   console.log('cols dont match')
-      //   errorMsg += ' Number of selected columns needs to match';
-      // }
       if (action.index === 0) {
         return {
           ...state,

--- a/client/src/state/reducers/document/index.ts
+++ b/client/src/state/reducers/document/index.ts
@@ -7,6 +7,7 @@ import {
   SET_COMPARISON_COLUMNS_ERROR,
   SET_ALL_COLUMNS
 } from '../../actions/document';
+import { addMessageToErrorList, removeMessageFromErrorList } from '../../../utils/update-comparison-columns';
 
 interface SelectedDocument {
   data: Array<any>;
@@ -60,61 +61,49 @@ const REQUIRED_ERR = 'At least 1 column is required';
 export const documentReducer = (state = initialState, action: any) => {
   switch (action.type) {
     case CHANGE_COMPARISON_COLUMN:
+      const { payload, index } = action;
       let errorMsg1 = [...state.comparisonColumns1Error];
       let errorMsg2 = [...state.comparisonColumns2Error];
-      const { payload, index } = action;
+      
       if (!!state.comparisonColumns1.length && !!state.comparisonColumns2.length) {
         if (
           (index === 0 && payload.length !== state.comparisonColumns2.length) ||
           (index === 1 && payload.length !== state.comparisonColumns1.length)
         ) {
-          console.log('cols dont match')
-          errorMsg1.push(MISMATCHED_COLUMNS_ERR);
-          errorMsg2.push(MISMATCHED_COLUMNS_ERR);
+          addMessageToErrorList(errorMsg1, MISMATCHED_COLUMNS_ERR);
+          addMessageToErrorList(errorMsg2, MISMATCHED_COLUMNS_ERR);
         } else if (
           (index === 0 && payload.length === state.comparisonColumns2.length) ||
           (index === 1 && payload.length === state.comparisonColumns1.length)
         ) {
-          const errIndex1 = errorMsg1.indexOf(MISMATCHED_COLUMNS_ERR);
-          const errIndex2 = errorMsg1.indexOf(MISMATCHED_COLUMNS_ERR);
-          if (errIndex1 > -1) errorMsg1.splice(errIndex1, 1);
-          if (errIndex2 > -1) errorMsg2.splice(errIndex2, 1);
+          removeMessageFromErrorList(errorMsg1, MISMATCHED_COLUMNS_ERR);
+          removeMessageFromErrorList(errorMsg2, MISMATCHED_COLUMNS_ERR);
         }
       }
       if (index === 0) {
         if (payload.length > 3) {
-          errorMsg1.push(TOO_MANY_COLUMNS_ERR);
-          console.log('-------------payload longer than 3', errorMsg1);
+          addMessageToErrorList(errorMsg1, TOO_MANY_COLUMNS_ERR);
         } else {
-          console.log('-------------payload shorter than 3');
-          const errIndex = errorMsg1.indexOf(TOO_MANY_COLUMNS_ERR);
-          if (errIndex > -1) errorMsg1.splice(errIndex, 1)
+          removeMessageFromErrorList(errorMsg1, TOO_MANY_COLUMNS_ERR);
         }
         if (payload.length === 0) {
-          errorMsg1.push(REQUIRED_ERR);
+          addMessageToErrorList(errorMsg1, REQUIRED_ERR);
         } else {
-          console.log('splicing req errr', errorMsg1, errorMsg1.indexOf(REQUIRED_ERR))
-          const errIndex = errorMsg1.indexOf(REQUIRED_ERR);
-          if (errIndex > -1) errorMsg1.splice(errIndex, 1);
+          removeMessageFromErrorList(errorMsg1, REQUIRED_ERR);
         }
-        console.log('errmessage1 after', errorMsg1)
       } else if (index === 1) {
         if (payload.length > 3) {
-          console.log('-------------payload longer than 3');
-          errorMsg2.push(TOO_MANY_COLUMNS_ERR)
+          addMessageToErrorList(errorMsg2, TOO_MANY_COLUMNS_ERR);
         } else {
-          console.log('-------------payload shorter than 3');
-          const errIndex = errorMsg2.indexOf(TOO_MANY_COLUMNS_ERR);
-          if (errIndex > -1) errorMsg2.splice(errIndex, 1);
+          removeMessageFromErrorList(errorMsg2, TOO_MANY_COLUMNS_ERR);
         }
         if (payload.length === 0) {
-          errorMsg2.push(REQUIRED_ERR);
+          addMessageToErrorList(errorMsg2, REQUIRED_ERR);
         } else {
-          const errIndex = errorMsg2.indexOf(REQUIRED_ERR);
-          if (errIndex > -1) errorMsg2.splice(errIndex, 1);
+          removeMessageFromErrorList(errorMsg2, REQUIRED_ERR);
         }
       }
-      console.log('error messages', errorMsg1, errorMsg2);
+
       if (action.index === 0) {
         return {
           ...state,
@@ -133,17 +122,19 @@ export const documentReducer = (state = initialState, action: any) => {
         };
       }
     case SET_COMPARISON_COLUMNS_ERROR:
+      const errorMsg = action.index === 0 ? [...state.comparisonColumns1Error] : [...state.comparisonColumns2Error];
+      if (action.payload.length === 0) {
+        addMessageToErrorList(errorMsg, REQUIRED_ERR);
+      }
       if (action.index === 0) {
         return {
           ...state,
-          comparisonColumns1Error: action.payload,
-          // comparisonColumns2Error: errorMsg
+          comparisonColumns1Error: errorMsg
         };
       } else {
         return {
           ...state,
-          comparisonColumns2Error: action.payload,
-          // comparisonColumns1Error: errorMsg
+          comparisonColumns2Error: errorMsg
         }
       }
     case CHANGE_RESULT_COLUMNS:

--- a/client/src/state/reducers/document/index.ts
+++ b/client/src/state/reducers/document/index.ts
@@ -64,21 +64,19 @@ export const documentReducer = (state = initialState, action: any) => {
       const { payload, index } = action;
       let errorMsg1 = [...state.comparisonColumns1Error];
       let errorMsg2 = [...state.comparisonColumns2Error];
-      
-      if (!!state.comparisonColumns1.length && !!state.comparisonColumns2.length) {
-        if (
-          (index === 0 && payload.length !== state.comparisonColumns2.length) ||
-          (index === 1 && payload.length !== state.comparisonColumns1.length)
-        ) {
-          addMessageToErrorList(errorMsg1, MISMATCHED_COLUMNS_ERR);
-          addMessageToErrorList(errorMsg2, MISMATCHED_COLUMNS_ERR);
-        } else if (
-          (index === 0 && payload.length === state.comparisonColumns2.length) ||
-          (index === 1 && payload.length === state.comparisonColumns1.length)
-        ) {
-          removeMessageFromErrorList(errorMsg1, MISMATCHED_COLUMNS_ERR);
-          removeMessageFromErrorList(errorMsg2, MISMATCHED_COLUMNS_ERR);
-        }
+
+      if (
+        (index === 0 && !!state.comparisonColumns2.length && payload.length !== state.comparisonColumns2.length) ||
+        (index === 1 && !!state.comparisonColumns1.length && payload.length !== state.comparisonColumns1.length)
+      ) {
+        addMessageToErrorList(errorMsg1, MISMATCHED_COLUMNS_ERR);
+        addMessageToErrorList(errorMsg2, MISMATCHED_COLUMNS_ERR);
+      } else if (
+        (index === 0 && payload.length === state.comparisonColumns2.length) ||
+        (index === 1 && payload.length === state.comparisonColumns1.length)
+      ) {
+        removeMessageFromErrorList(errorMsg1, MISMATCHED_COLUMNS_ERR);
+        removeMessageFromErrorList(errorMsg2, MISMATCHED_COLUMNS_ERR);
       }
       if (index === 0) {
         if (payload.length > 3) {

--- a/client/src/utils/update-comparison-columns.ts
+++ b/client/src/utils/update-comparison-columns.ts
@@ -9,3 +9,19 @@ export const updateComparisonColumns = (comparisonColumns: Array<string>, update
   }
   return newValue;
 }
+
+export const addMessageToErrorList = (
+  errorList: Array<string>,
+  errorMessage: string,
+) => {
+  const errMsgIndex = errorList.indexOf(errorMessage);
+  if (errMsgIndex === -1) errorList.push(errorMessage);
+}
+
+export const removeMessageFromErrorList = (
+  errorList: Array<string>,
+  errorMessage: string,
+) => {
+  const errMsgIndex = errorList.indexOf(errorMessage);
+  if (errMsgIndex > -1) errorList.splice(errMsgIndex, 1);
+}


### PR DESCRIPTION
Error messages appear if you leave the comparison columns empty, if you put in too many, or if they don't match.